### PR TITLE
Use the inscription that contains only the required fflate function

### DIFF
--- a/p5js/page-structure.html
+++ b/p5js/page-structure.html
@@ -5,10 +5,8 @@ newS=document.createElement('script');
 newS.innerHTML=fflate.strFromU8(fflate.gunzipSync(new Uint8Array(Array.from(atob(td)).map((char)=>char.charCodeAt(0)))))+";fflateCallback2()";
 document.body.appendChild(newS);}
 (async function(){
-resp=await fetch(`/content/2dbdf9ebbec6be793fd16ae9b797c7cf968ab2427166aaf390b90b71778266abi0`);
-html=await resp.text();
-htmlLines=html.split("\n");
-fflateS=htmlLines[28];
+fflateR=await fetch(`/content/6bac7ab4ce8d5d32f202c2e31bba2b5476a18275802b4e0595c708760f9f56b5i0`);
+fflateS=await fflateR.text();
 p5r=await fetch(`/content/255ce0c5a0d8aca39510da72e604ef8837519028827ba7b7f723b7489f3ec3a4i0`);
 p5S=`const d3="${await p5r.text()}"`;
 ffCS="fflateCallback();";


### PR DESCRIPTION
This updates the p5.js code to use the same fflate inscription as the one in [browserUI](https://github.com/metagood/OCM-Dimensions/blob/main/browserUI/index.html#L16).

No need to load a larger HTML file and get fflate from a specific line number.