### PR TITLE
Remove unnecessary div

### DIFF
--- a/p5js/page-structure.html
+++ b/p5js/page-structure.html
@@ -1,4 +1,4 @@
-<html><head><meta charset="utf-8"><style>body{margin:0;}</style></head><body><div id="scene"></div><script>
+<html><head><meta charset="utf-8"><style>body{margin:0;}</style></head><body><script>
 td='SRC_COMPRESSED_STRING';
 function fflateCallback(){
 newS=document.createElement('script');


### PR DESCRIPTION
This `div` seems unnecessary as `p5.js` creates its own canvas tag at the root level.